### PR TITLE
use push constants

### DIFF
--- a/Source/Components/Transform/TransformComponent.h
+++ b/Source/Components/Transform/TransformComponent.h
@@ -18,7 +18,6 @@ namespace JoeEngine {
         ~TransformComponent() {}
 
         void RecomputeTransform() {
-            glm::mat4 mat = glm::toMat4(m_rotation);
             m_cachedTransform = glm::translate(glm::mat4(1.0f), m_translation) * glm::toMat4(m_rotation) * glm::scale(glm::mat4(1.0f), m_scale);
         }
 

--- a/Source/Components/Transform/TransformComponentManager.cpp
+++ b/Source/Components/Transform/TransformComponentManager.cpp
@@ -2,8 +2,9 @@
 
 namespace JoeEngine {
     void JETransformComponentManager::Update() {
-        for (TransformComponent t : m_transformComponents) {
-            // TODO: something
+        for (TransformComponent& t : m_transformComponents) {
+            // TODO: something?
+            t.SetRotation(t.GetRotation() * glm::angleAxis(0.01f, glm::vec3(0, 1, 0)));
         }
     }
 

--- a/Source/EngineInstance.h
+++ b/Source/EngineInstance.h
@@ -32,8 +32,6 @@ namespace JoeEngine {
         };
 
         std::vector<std::unique_ptr<JEComponentManager>> m_componentManagers;
-        //JEMeshComponentManager m_meshComponentManager;
-        //JEMaterialComponentManager m_materialComponentManager;
 
         double m_frameStartTime, m_frameEndTime; // timing for performance analysis
         bool m_enableFrameCounter;
@@ -43,7 +41,7 @@ namespace JoeEngine {
         void StopEngine();
 
     public:
-        JEEngineInstance() : m_enableFrameCounter(false), m_frameStartTime(0.0f), m_frameEndTime(0.0f) {
+        JEEngineInstance() : m_enableFrameCounter(true), m_frameStartTime(0.0f), m_frameEndTime(0.0f) {
             InitializeEngine();
         }
         ~JEEngineInstance() {}

--- a/Source/Rendering/VulkanRenderer.h
+++ b/Source/Rendering/VulkanRenderer.h
@@ -12,6 +12,7 @@
 #include "VulkanRenderingTypes.h"
 #include "MeshBufferManager.h"
 #include "../Components/Mesh/MeshComponent.h"
+#include "../Components/Transform/TransformComponent.h"
 
 namespace JoeEngine {
     class JESceneManager;
@@ -139,7 +140,7 @@ namespace JoeEngine {
         void DrawMesh(VkCommandBuffer commandBuffer, const MeshComponent& meshComponent);
         void DrawScreenSpaceTriMesh(VkCommandBuffer commandBuffer);
 
-        void UpdateShaderUniformBuffers(uint32_t imageIndex, const std::vector<glm::mat4>& transforms);
+        void UpdateShaderUniformBuffers(uint32_t imageIndex);
 
     public:
         JEVulkanRenderer() : m_width(JE_DEFAULT_SCREEN_WIDTH), m_height(JE_DEFAULT_SCREEN_HEIGHT), m_MAX_FRAMES_IN_FLIGHT(JE_DEFAULT_MAX_FRAMES_IN_FLIGHT),
@@ -162,8 +163,8 @@ namespace JoeEngine {
         MeshComponent CreateMesh(const std::string& filepath);
 
         // Renderer Functions
-        void DrawShadowPass(const std::vector<MeshComponent>& meshComponents);
-        void DrawMeshComponents(const std::vector<MeshComponent>& meshComponents);
+        void DrawShadowPass(const std::vector<MeshComponent>& meshComponents, const std::vector<TransformComponent>& transformComponents, const JECamera& camera);
+        void DrawMeshComponents(const std::vector<MeshComponent>& meshComponents, const std::vector<TransformComponent>& transformComponents, const JECamera& camera);
 
         void WaitForIdleDevice() {
             vkDeviceWaitIdle(m_device);

--- a/Source/Scene/SceneManager.cpp
+++ b/Source/Scene/SceneManager.cpp
@@ -12,83 +12,65 @@ namespace JoeEngine {
         m_currentScene = sceneId;
         if (sceneId == 0) {
             std::vector<Entity> entities;
-            MeshComponent meshComp = m_engineInstance->CreateMeshComponent(JE_MODELS_OBJ_DIR + "wahoo.obj");
-            for (int i = 0; i < 10; ++i) {
-                entities.emplace_back(m_engineInstance->SpawnEntity());
-                m_engineInstance->SetMeshComponent(entities[i], meshComp);
+            MeshComponent meshComp_wahoo = m_engineInstance->CreateMeshComponent(JE_MODELS_OBJ_DIR + "wahoo.obj");
+            for (uint32_t i = 0; i < 10000; ++i) {
+                Entity newEntity = m_engineInstance->SpawnEntity();
+                entities.push_back(newEntity);
+                m_engineInstance->SetMeshComponent(newEntity.m_id, meshComp_wahoo);
             }
+            
+            Entity newEntity = m_engineInstance->SpawnEntity();
+            entities.push_back(newEntity);
+            MeshComponent meshComp_plane = m_engineInstance->CreateMeshComponent(JE_MODELS_OBJ_DIR + "plane.obj");
+            m_engineInstance->SetMeshComponent(entities[newEntity.m_id], meshComp_plane);
+            TransformComponent* trans = m_engineInstance->GetTransformComponent(entities[newEntity.m_id]);
+            trans->SetTranslation(glm::vec3(0.0f, -3.0f, 0.0f));
+            trans->SetRotation(glm::angleAxis(-90.0f, glm::vec3(1, 0, 0)));
+            trans->SetScale(glm::vec3(50.0f, 50.0f, 1.0f));
 
-            TransformComponent* trans = m_engineInstance->GetTransformComponent(entities[0]);
+            trans = m_engineInstance->GetTransformComponent(entities[0]);
             trans->SetTranslation(glm::vec3(0.0f, 0.0f, 0.0f));
-            trans->SetScale(glm::vec3(0.5f, 0.5f, 0.5f));
+            trans->SetScale(glm::vec3(0.05f, 0.05f, 0.05f));
 
             trans = m_engineInstance->GetTransformComponent(entities[1]);
             trans->SetTranslation(glm::vec3(-0.5f, 3.0f, 0.0f));
-            trans->SetScale(glm::vec3(0.5f, 0.5f, 0.5f));
+            trans->SetScale(glm::vec3(0.05f, 0.05f, 0.05f));
 
             trans = m_engineInstance->GetTransformComponent(entities[2]);
             trans->SetTranslation(glm::vec3(1.f, -1.0f, 0.0f));
-            trans->SetScale(glm::vec3(0.5f, 0.5f, 0.5f));
+            trans->SetScale(glm::vec3(0.05f, 0.05f, 0.05f));
 
             trans = m_engineInstance->GetTransformComponent(entities[3]);
             trans->SetTranslation(glm::vec3(2.0f, -2.0f, 0.0f));
-            trans->SetScale(glm::vec3(0.5f, 0.5f, 0.5f));
+            trans->SetScale(glm::vec3(0.05f, 0.05f, 0.05f));
 
             trans = m_engineInstance->GetTransformComponent(entities[4]);
             trans->SetTranslation(glm::vec3(3.0f, -2.0f, 0.0f));
-            trans->SetScale(glm::vec3(0.5f, 0.5f, 0.5f));
+            trans->SetScale(glm::vec3(0.05f, 0.05f, 0.05f));
 
             trans = m_engineInstance->GetTransformComponent(entities[5]);
             trans->SetTranslation(glm::vec3(4.0f, -1.0f, 0.0f));
-            trans->SetScale(glm::vec3(0.5f, 0.5f, 0.5f));
+            trans->SetScale(glm::vec3(0.05f, 0.05f, 0.05f));
 
             trans = m_engineInstance->GetTransformComponent(entities[6]);
             trans->SetTranslation(glm::vec3(5.0f, 0.0f, 0.0f));
-            trans->SetScale(glm::vec3(0.5f, 0.5f, 0.5f));
+            trans->SetScale(glm::vec3(0.05f, 0.05f, 0.05f));
 
             trans = m_engineInstance->GetTransformComponent(entities[7]);
             trans->SetTranslation(glm::vec3(6.0f, 1.0f, 0.0f));
-            trans->SetScale(glm::vec3(0.5f, 0.5f, 0.5f));
+            trans->SetScale(glm::vec3(0.05f, 0.05f, 0.05f));
 
             trans = m_engineInstance->GetTransformComponent(entities[8]);
             trans->SetTranslation(glm::vec3(7.0f, 2.0f, 0.0f));
-            trans->SetScale(glm::vec3(0.5f, 0.5f, 0.5f));
+            trans->SetScale(glm::vec3(0.05f, 0.05f, 0.05f));
 
             trans = m_engineInstance->GetTransformComponent(entities[9]);
             trans->SetTranslation(glm::vec3(6.5f, 10.0f, 0.0f));
-            trans->SetScale(glm::vec3(0.5f, 0.5f, 0.5f));
-
-            // Meshes
-            /*m_meshDataManager->CreateNewMesh(physicalDevice, device, commandPool, graphicsQueue, JE_MODELS_OBJ_DIR + "cube.obj", JE_PHYSICS_FREEZE_POSITION | JE_PHYSICS_FREEZE_ROTATION);
-            m_meshDataManager->CreateNewMesh(physicalDevice, device, commandPool, graphicsQueue, JE_MODELS_OBJ_DIR + "cube.obj", JE_PHYSICS_FREEZE_NONE);
-            m_meshDataManager->CreateNewMesh(physicalDevice, device, commandPool, graphicsQueue, JE_MODELS_OBJ_DIR + "cube.obj", JE_PHYSICS_FREEZE_POSITION | JE_PHYSICS_FREEZE_ROTATION);
-            m_meshDataManager->CreateNewMesh(physicalDevice, device, commandPool, graphicsQueue, JE_MODELS_OBJ_DIR + "cube.obj", JE_PHYSICS_FREEZE_POSITION | JE_PHYSICS_FREEZE_ROTATION);
-            m_meshDataManager->CreateNewMesh(physicalDevice, device, commandPool, graphicsQueue, JE_MODELS_OBJ_DIR + "cube.obj", JE_PHYSICS_FREEZE_POSITION | JE_PHYSICS_FREEZE_ROTATION);
-            m_meshDataManager->CreateNewMesh(physicalDevice, device, commandPool, graphicsQueue, JE_MODELS_OBJ_DIR + "cube.obj", JE_PHYSICS_FREEZE_POSITION | JE_PHYSICS_FREEZE_ROTATION);
-            m_meshDataManager->CreateNewMesh(physicalDevice, device, commandPool, graphicsQueue, JE_MODELS_OBJ_DIR + "cube.obj", JE_PHYSICS_FREEZE_POSITION | JE_PHYSICS_FREEZE_ROTATION);
-            m_meshDataManager->CreateNewMesh(physicalDevice, device, commandPool, graphicsQueue, JE_MODELS_OBJ_DIR + "cube.obj", JE_PHYSICS_FREEZE_POSITION | JE_PHYSICS_FREEZE_ROTATION);
-            m_meshDataManager->CreateNewMesh(physicalDevice, device, commandPool, graphicsQueue, JE_MODELS_OBJ_DIR + "cube.obj", JE_PHYSICS_FREEZE_POSITION | JE_PHYSICS_FREEZE_ROTATION);
-            m_meshDataManager->CreateNewMesh(physicalDevice, device, commandPool, graphicsQueue, JE_MODELS_OBJ_DIR + "cube.obj", JE_PHYSICS_FREEZE_NONE);
-            m_meshDataManager->SetMeshPosition(glm::vec3(0.0f, 0.0f, 0.0f), 0);
-            m_meshDataManager->SetMeshPosition(glm::vec3(-0.5f, 3.0f, 0.0f), 1);
-            m_meshDataManager->SetMeshPosition(glm::vec3(1.f, -1.0f, 0.0f), 2);
-            m_meshDataManager->SetMeshPosition(glm::vec3(2.0f, -2.0f, 0.0f), 3);
-            m_meshDataManager->SetMeshPosition(glm::vec3(3.0f, -2.0f, 0.0f), 4);
-            m_meshDataManager->SetMeshPosition(glm::vec3(4.0f, -1.0f, 0.0f), 5);
-            m_meshDataManager->SetMeshPosition(glm::vec3(5.0f, 0.0f, 0.0f), 6);
-            m_meshDataManager->SetMeshPosition(glm::vec3(6.0f, 1.0f, 0.0f), 7);
-            m_meshDataManager->SetMeshPosition(glm::vec3(7.0f, 2.0f, 0.0f), 8);
-            m_meshDataManager->SetMeshPosition(glm::vec3(6.5f, 10.0f, 0.0f), 9);
-
-            // Screen space triangle setup
-            m_meshDataManager->CreateScreenSpaceTriangleMesh(physicalDevice, device, commandPool, graphicsQueue);*/
+            trans->SetScale(glm::vec3(0.05f, 0.05f, 0.05f));
 
             // Camera
             m_camera = JECamera(glm::vec3(0.0f, 4.0f, 12.0f), glm::vec3(0.0f, 0.0f, 0.0f), windowExtent.width / (float)windowExtent.height, JE_SCENE_VIEW_NEAR_PLANE, JE_SCENE_VIEW_FAR_PLANE);
-            m_shadowCamera = JECamera(glm::vec3(5.0f, 5.0f, 5.0f), glm::vec3(0.0f, 0.0f, 0.0f), shadowPassExtent.width / (float)shadowPassExtent.height, JE_SHADOW_VIEW_NEAR_PLANE, JE_SHADOW_VIEW_FAR_PLANE);
-
-            // Shaders
-            //CreateShaders(physicalDevice, device, vulkanSwapChain, renderPass_deferredLighting, deferredLightingImageView, shadowPass, deferredPass, postProcessingPasses);
+            m_shadowCamera = JECamera(glm::vec3(35.0f, 35.0f, 35.0f), glm::vec3(0.0f, 0.0f, 0.0f), shadowPassExtent.width / (float)shadowPassExtent.height, JE_SHADOW_VIEW_NEAR_PLANE, JE_SHADOW_VIEW_FAR_PLANE);
         } else if (sceneId == 1) {
             // Meshes
             /*m_meshDataManager->CreateNewMesh(physicalDevice, device, commandPool, graphicsQueue, JE_MODELS_OBJ_DIR + "cube.obj", JE_PHYSICS_FREEZE_POSITION | JE_PHYSICS_FREEZE_ROTATION);

--- a/Source/Scripts/compileShaders_nonBuild.bat
+++ b/Source/Scripts/compileShaders_nonBuild.bat
@@ -1,5 +1,5 @@
 echo Compiling Shaders...
-cd ..\Source\Shaders\
+cd ..\Shaders\
 for %%i in (*.vert) do %VULKAN_SDK%\Bin32\glslangValidator.exe -V %%i -o %%~ni.spv
 for %%i in (*.frag) do %VULKAN_SDK%\Bin32\glslangValidator.exe -V %%i -o %%~ni.spv
 echo Done.

--- a/Source/Shaders/frag_deferred_geom.frag
+++ b/Source/Shaders/frag_deferred_geom.frag
@@ -1,7 +1,7 @@
 #version 450
 #extension GL_ARB_separate_shader_objects : enable
 
-layout(binding = 2) uniform sampler2D albedo;
+layout(binding = 0) uniform sampler2D albedo;
 
 layout(location = 0) in vec3 fragColor;
 layout(location = 1) in vec2 fragUV;

--- a/Source/Shaders/frag_deferred_lighting.frag
+++ b/Source/Shaders/frag_deferred_lighting.frag
@@ -27,19 +27,25 @@ void main() {
     vec3 gBuffer_Normal = texture(gBufferNormal, fragUV).xyz * 2 - 1;
 
     // Get world space position from fragment position and depth
-    vec3 ndcPos = vec3(fragPos, texture(gBufferDepth, fragUV).x);
+    float depth = texture(gBufferDepth, fragUV).r;
+    vec3 ndcPos = vec3(fragPos, depth);
     vec4 viewPos = ubo_viewProj_inv.invProj * vec4(ndcPos, 1.0);
     viewPos /= viewPos.w;
     vec3 worldPos = (ubo_viewProj_inv.invView * viewPos).xyz;
+    //outColor = vec4(worldPos, 1); return;
 
     // Shadow mapping
-    worldPos += normalize(vec3(5.0) - worldPos) * 0.005;
+    worldPos += normalize(vec3(20.0) - worldPos) * 0.01;
     vec4 pointShadow = ubo_viewProj_Shadow.viewProj * vec4(worldPos, 1.0);
-    pointShadow /= pointShadow.w;
+    //pointShadow /= pointShadow.w;
     pointShadow.xy = pointShadow.xy * 0.5 + 0.5;
+    //outColor = vec4(vec3(pointShadow.z), 1.0); return;
+    
     float shadowColor = texture(shadowMap, pointShadow.xy).r;
     float shadow = step(pointShadow.z, shadowColor);
     shadow = max(shadow, 0.15);
-    float lambert = clamp(dot(normalize(vec3(5.0)), gBuffer_Normal), 0.0, 1.0);
+    float lambert = clamp(dot(normalize(vec3(20.0)), gBuffer_Normal), 0.0, 1.0);
     outColor = vec4(gBuffer_Color * shadow * lambert, 1.0);
+    //outColor = vec4(vec3(shadowColor), 1.0);
+    //outColor = vec4(vec3(pointShadow), 1.0);
 }

--- a/Source/Shaders/vert_deferred_geom.vert
+++ b/Source/Shaders/vert_deferred_geom.vert
@@ -1,13 +1,10 @@
 #version 450
 #extension GL_ARB_separate_shader_objects : enable
 
-layout(binding = 0) uniform UBO_ViewProj {
+layout (push_constant) uniform PushConstant {
     mat4 viewProj;
-} ubo_viewProj;
-
-layout (binding = 1) uniform UBODynamic_ModelMat {
-	mat4 model;
-} uboDynamicModelMatInstance;
+    mat4 model;
+} pushConstants;
 
 layout(location = 0) in vec3 inPosition;
 layout(location = 1) in vec3 inNormal;
@@ -24,10 +21,10 @@ out gl_PerVertex {
 };
 
 void main() {
-    vec3 pos = (uboDynamicModelMatInstance.model * vec4(inPosition, 1.0)).xyz;
+    vec3 pos = (pushConstants.model * vec4(inPosition, 1.0)).xyz;
     fragPos = pos;
-    fragNor = normalize((inverse(transpose(uboDynamicModelMatInstance.model)) * vec4(inNormal, 0)).xyz);
-    gl_Position = ubo_viewProj.viewProj * vec4(pos, 1.0);
+    fragNor = normalize((transpose(inverse(pushConstants.model)) * vec4(inNormal, 0)).xyz);
+    gl_Position = pushConstants.viewProj * vec4(pos, 1.0);
     fragUV = inUV;
     fragColor = inColor;
 }

--- a/Source/Shaders/vert_shadow.vert
+++ b/Source/Shaders/vert_shadow.vert
@@ -1,13 +1,10 @@
 #version 450
 #extension GL_ARB_separate_shader_objects : enable
 
-layout(binding = 0) uniform UBO_ViewProj {
+layout (push_constant) uniform PushConstant {
     mat4 viewProj;
-} ubo_viewProj;
-
-layout (binding = 1) uniform UBODynamic_ModelMat {
-	mat4 model;
-} uboDynamicModelMatInstance;
+    mat4 model;
+} pushConstants;
 
 layout(location = 0) in vec3 inPosition;
 layout(location = 1) in vec3 inColor;
@@ -18,5 +15,5 @@ out gl_PerVertex {
 };
 
 void main() {
-    gl_Position = ubo_viewProj.viewProj * uboDynamicModelMatInstance.model * vec4(inPosition, 1.0);
+    gl_Position = pushConstants.viewProj * pushConstants.model * vec4(inPosition, 1.0);
 }

--- a/Source/Utils/Common.h
+++ b/Source/Utils/Common.h
@@ -23,7 +23,7 @@ namespace JoeEngine {
 
     constexpr int JE_DEFAULT_SHADOW_MAP_WIDTH = 2000;
     constexpr int JE_DEFAULT_SHADOW_MAP_HEIGHT = 2000;
-    constexpr float JE_DEFAULT_SHADOW_MAP_DEPTH_BIAS_SLOPE = 1.5f;
+    constexpr float JE_DEFAULT_SHADOW_MAP_DEPTH_BIAS_SLOPE = 1.0f;
     constexpr float JE_DEFAULT_SHADOW_MAP_DEPTH_BIAS_CONSTANT = 0.0f;
 
     // Camera attributes
@@ -31,8 +31,8 @@ namespace JoeEngine {
     constexpr float JE_SCENE_VIEW_NEAR_PLANE = 0.1f;
     constexpr float JE_SCENE_VIEW_FAR_PLANE = 100.0f;
     constexpr float JE_SHADOW_VIEW_NEAR_PLANE = 0.1f;
-    constexpr float JE_SHADOW_VIEW_FAR_PLANE = 50.0f;
-    const float JE_FOVY = glm::radians(45.0f);
+    constexpr float JE_SHADOW_VIEW_FAR_PLANE = 100.0f;
+    const float JE_FOVY = glm::radians(22.5f);
 
     // Vulkan Functions
     VkCommandBuffer BeginSingleTimeCommands(VkDevice device, VkCommandPool commandPool);


### PR DESCRIPTION
- use push constants instead of ubo for model/viewproj matrices (close #30).
- rebuild command buffer every frame
- debug and fix shadow mapping
- able to stress test component manager update time (currently 3ms to update 10k transform components)